### PR TITLE
Add testing (from issue #4834) to PR #5336.

### DIFF
--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -5466,3 +5466,30 @@ def test_outputs_taps_check():
     outputs_info = {'initial': y, 'taps': [-1, -1]}
     assert_raises(ValueError, theano.scan, f, x, outputs_info)
     print('done')
+
+
+def test_default_value_broadcasted():
+    def floatx(X):
+        return numpy.asarray(X, dtype=theano.config.floatX)
+
+    def init_weights(shape, name):
+        return theano.shared(floatx(numpy.random.randn(*shape) * 0.1), name)
+
+    X = theano.tensor.matrix('X')
+    in_size = 2
+    out_size = 4
+    W_x = init_weights((in_size, out_size), "W_x")
+
+    def _active(x, pre_h):
+        x = theano.tensor.reshape(x, (1, in_size))
+        pre_h = theano.tensor.dot(x, W_x)
+        return pre_h
+
+    value, scan_updates = theano.scan(_active, sequences=X,
+                                      outputs_info=[theano.tensor.alloc(floatx(0.), 1, out_size)])
+    cost = theano.tensor.mean(value)
+    gW_x = theano.tensor.grad(cost, W_x)
+    updates = [(W_x, W_x - 0.1 * gW_x)]
+    f = theano.function([X], outputs=cost, updates=updates)
+    test = f(numpy.random.rand(10, in_size))
+    print(test)

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -5491,5 +5491,5 @@ def test_default_value_broadcasted():
     gW_x = theano.tensor.grad(cost, W_x)
     updates = [(W_x, W_x - 0.1 * gW_x)]
     f = theano.function([X], outputs=cost, updates=updates)
-    test = f(numpy.random.rand(10, in_size))
+    test = f(numpy.random.rand(10, in_size).astype(X.dtype))
     print(test)


### PR DESCRIPTION
Add testing (from issue #4834) to PR #5336.
Test: `theano/scan_module/tests/test_scan.py:test_default_value_broadcasted`
Tested on Python 2 and 3.

```
(python2) ~/mila/dev/git/theano$ nosetests -vs theano/scan_module/tests/test_scan.py:test_default_value_broadcasted
theano.scan_module.tests.test_scan.test_default_value_broadcasted ... -0.0352730637786
ok

----------------------------------------------------------------------
Ran 1 test in 6.516s

OK
```

NB: This test takes at least 6 seconds on my computer.

@lamblin 